### PR TITLE
Replace deprecated free margin constant in expert advisor

### DIFF
--- a/Enhanced_ST_VWAP_Project/mql5/Experts/Enhanced_ST_VWAP_EA.mq5
+++ b/Enhanced_ST_VWAP_Project/mql5/Experts/Enhanced_ST_VWAP_EA.mq5
@@ -583,7 +583,8 @@ bool CheckPositionLimits()
 //+------------------------------------------------------------------+
 double CalculateDynamicLot()
 {
-    double accountSize = AccountInfoDouble(ACCOUNT_FREEMARGIN);
+    // ACCOUNT_FREEMARGIN is deprecated; use ACCOUNT_MARGIN_FREE instead
+    double accountSize = AccountInfoDouble(ACCOUNT_MARGIN_FREE);
     double riskAmount = accountSize * RiskPct / 100.0;
     
     // Calculate lot based on stop loss distance


### PR DESCRIPTION
## Summary
- Replace deprecated ACCOUNT_FREEMARGIN with ACCOUNT_MARGIN_FREE in dynamic lot calculation.

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `metaeditor64 /compile:Enhanced_ST_VWAP_Project/mql5/Experts/Enhanced_ST_VWAP_EA.mq5` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af14546cec83299a8fb5e5feb08df9